### PR TITLE
feat(net-worth): add net worth tracker with dashboard card and report…

### DIFF
--- a/src-tauri/migrations/20240208000001_net_worth.sql
+++ b/src-tauri/migrations/20240208000001_net_worth.sql
@@ -1,0 +1,11 @@
+-- File: src-tauri/migrations/20240208000001_net_worth.sql
+CREATE TABLE IF NOT EXISTS net_worth_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_date TEXT NOT NULL,
+    total_assets REAL NOT NULL DEFAULT 0,
+    total_liabilities REAL NOT NULL DEFAULT 0,
+    net_worth REAL NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_networth_date ON net_worth_snapshots(snapshot_date);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod credit_cards;
 pub mod currencies;
 pub mod export;
 pub mod installments;
+pub mod networth;
 pub mod photos;
 pub mod recurring;
 pub mod security;

--- a/src-tauri/src/commands/networth.rs
+++ b/src-tauri/src/commands/networth.rs
@@ -1,0 +1,265 @@
+// File: src-tauri/src/commands/networth.rs
+use crate::models::networth::{NetWorthSnapshot, NetWorthSummary};
+use chrono::{Datelike, Local, NaiveDate};
+use sqlx::{Row, SqlitePool};
+use tauri::State;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Calculate assets & liabilities from live account balances up to a given date.
+/// If `as_of_date` is None, calculates current (all-time) balances.
+async fn calc_net_worth_at(
+    pool: &SqlitePool,
+    as_of_date: Option<&str>,
+) -> Result<(f64, f64), String> {
+    let rows = match as_of_date {
+        Some(date) => {
+            sqlx::query(
+                r#"
+                SELECT a.initial_balance, ag.type as account_type,
+                       CAST(COALESCE(
+                           (SELECT SUM(je2.debit) - SUM(je2.credit)
+                            FROM journal_entries je2
+                            JOIN transactions t2 ON je2.transaction_id = t2.id
+                            WHERE je2.account_id = a.id AND t2.date <= ?),
+                       0) AS REAL) as journal_balance
+                FROM accounts a
+                JOIN account_groups ag ON a.group_id = ag.id
+                GROUP BY a.id
+                "#,
+            )
+            .bind(date)
+            .fetch_all(pool)
+            .await
+        }
+        None => {
+            sqlx::query(
+                r#"
+                SELECT a.initial_balance, ag.type as account_type,
+                       CAST(COALESCE(SUM(je.debit), 0) - COALESCE(SUM(je.credit), 0) AS REAL) as journal_balance
+                FROM accounts a
+                JOIN account_groups ag ON a.group_id = ag.id
+                LEFT JOIN journal_entries je ON je.account_id = a.id
+                GROUP BY a.id
+                "#,
+            )
+            .fetch_all(pool)
+            .await
+        }
+    }
+    .map_err(|e| format!("Failed to calculate net worth: {}", e))?;
+
+    let mut assets = 0.0_f64;
+    let mut liabilities = 0.0_f64;
+
+    for row in rows.iter() {
+        let initial: f64 = row.get("initial_balance");
+        let journal: f64 = row.get("journal_balance");
+        let balance = initial + journal;
+        let acc_type: String = row.get("account_type");
+        match acc_type.as_str() {
+            "ASSET" => assets += balance,
+            "LIABILITY" => liabilities += (-balance).max(0.0),
+            _ => {}
+        }
+    }
+
+    Ok((
+        (assets * 100.0).round() / 100.0,
+        (liabilities * 100.0).round() / 100.0,
+    ))
+}
+
+/// Return the last day of a given year/month.
+fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
+    if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    }
+    .and_then(|d| d.pred_opt())
+    .unwrap_or_else(|| NaiveDate::from_ymd_opt(year, month, 28).unwrap())
+}
+
+// ── Commands ─────────────────────────────────────────────────────────
+
+/// Live net worth with month-over-month change.
+#[tauri::command]
+pub async fn get_current_net_worth(pool: State<'_, SqlitePool>) -> Result<NetWorthSummary, String> {
+    let (assets, liabilities) = calc_net_worth_at(pool.inner(), None).await?;
+    let net_worth = assets - liabilities;
+
+    // Previous month-end for comparison
+    let today = Local::now().date_naive();
+    let first_of_month =
+        NaiveDate::from_ymd_opt(today.year(), today.month(), 1).ok_or("Invalid date")?;
+    let prev_month_end = first_of_month.pred_opt().ok_or("Invalid date")?;
+    let prev_date_str = prev_month_end.format("%Y-%m-%d").to_string();
+
+    let (prev_assets, prev_liabilities) =
+        calc_net_worth_at(pool.inner(), Some(&prev_date_str)).await?;
+    let prev_net_worth = prev_assets - prev_liabilities;
+
+    let change_amount = ((net_worth - prev_net_worth) * 100.0).round() / 100.0;
+    let change_percentage = if prev_net_worth.abs() > 0.01 {
+        ((change_amount / prev_net_worth.abs()) * 100.0 * 100.0).round() / 100.0
+    } else {
+        0.0
+    };
+
+    Ok(NetWorthSummary {
+        assets,
+        liabilities,
+        net_worth,
+        change_amount,
+        change_percentage,
+    })
+}
+
+/// Return persisted monthly snapshots for the chart.
+/// Falls back to the existing `net_worth_snapshots` table.
+#[tauri::command]
+pub async fn get_net_worth_snapshots(
+    pool: State<'_, SqlitePool>,
+    months: Option<i64>,
+) -> Result<Vec<NetWorthSnapshot>, String> {
+    let limit = months.unwrap_or(12);
+
+    let rows = sqlx::query(
+        "SELECT id, snapshot_date, total_assets, total_liabilities, net_worth
+         FROM net_worth_snapshots
+         ORDER BY snapshot_date DESC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool.inner())
+    .await
+    .map_err(|e| format!("Failed to fetch snapshots: {}", e))?;
+
+    let mut snapshots: Vec<NetWorthSnapshot> = rows
+        .iter()
+        .map(|r| NetWorthSnapshot {
+            id: r.get("id"),
+            snapshot_date: r.get("snapshot_date"),
+            total_assets: r.get("total_assets"),
+            total_liabilities: r.get("total_liabilities"),
+            net_worth: r.get("net_worth"),
+        })
+        .collect();
+
+    // Return in chronological order (oldest first) for the chart
+    snapshots.reverse();
+    Ok(snapshots)
+}
+
+/// Create a snapshot for the current month if one doesn't exist yet.
+/// Called from `lib.rs` setup — runs silently on every app start.
+pub async fn generate_net_worth_snapshot(pool: &SqlitePool) -> Result<(), String> {
+    let today = Local::now().date_naive();
+    let snapshot_date = last_day_of_month(today.year(), today.month());
+    let date_str = snapshot_date.format("%Y-%m-%d").to_string();
+
+    // Check if snapshot already exists for this month
+    let exists = sqlx::query("SELECT id FROM net_worth_snapshots WHERE snapshot_date = ?")
+        .bind(&date_str)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| format!("DB error: {}", e))?
+        .is_some();
+
+    if exists {
+        // Update existing snapshot with current values
+        let (assets, liabilities) = calc_net_worth_at(pool, None).await?;
+        let net_worth = assets - liabilities;
+
+        sqlx::query(
+            "UPDATE net_worth_snapshots SET total_assets = ?, total_liabilities = ?, net_worth = ? WHERE snapshot_date = ?"
+        )
+        .bind(assets)
+        .bind(liabilities)
+        .bind(net_worth)
+        .bind(&date_str)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("Failed to update snapshot: {}", e))?;
+    } else {
+        let (assets, liabilities) = calc_net_worth_at(pool, None).await?;
+        let net_worth = assets - liabilities;
+
+        sqlx::query(
+            "INSERT INTO net_worth_snapshots (snapshot_date, total_assets, total_liabilities, net_worth) VALUES (?, ?, ?, ?)"
+        )
+        .bind(&date_str)
+        .bind(assets)
+        .bind(liabilities)
+        .bind(net_worth)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("Failed to insert snapshot: {}", e))?;
+    }
+
+    Ok(())
+}
+
+/// One-time backfill: replay history from the earliest transaction month to now.
+/// Only runs if the snapshots table is empty.
+pub async fn backfill_net_worth_snapshots(pool: &SqlitePool) -> Result<(), String> {
+    // Check if we already have snapshots
+    let count_row = sqlx::query("SELECT COUNT(*) as cnt FROM net_worth_snapshots")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| format!("DB error: {}", e))?;
+    let count: i64 = count_row.get("cnt");
+    if count > 0 {
+        return Ok(()); // Already populated
+    }
+
+    // Find earliest transaction date
+    let earliest = sqlx::query("SELECT MIN(date) as min_date FROM transactions")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| format!("DB error: {}", e))?;
+
+    let min_date_str: Option<String> = earliest.get("min_date");
+    let start = match min_date_str {
+        Some(d) => NaiveDate::parse_from_str(&d, "%Y-%m-%d")
+            .map_err(|_| "Failed to parse earliest date".to_string())?,
+        None => return Ok(()), // No transactions, nothing to backfill
+    };
+
+    let today = Local::now().date_naive();
+    let mut year = start.year();
+    let mut month = start.month();
+
+    loop {
+        let end_of_month = last_day_of_month(year, month);
+        if end_of_month > today {
+            break; // Current month will be handled by generate_net_worth_snapshot
+        }
+
+        let date_str = end_of_month.format("%Y-%m-%d").to_string();
+        let (assets, liabilities) = calc_net_worth_at(pool, Some(&date_str)).await?;
+        let net_worth = assets - liabilities;
+
+        sqlx::query(
+            "INSERT OR IGNORE INTO net_worth_snapshots (snapshot_date, total_assets, total_liabilities, net_worth) VALUES (?, ?, ?, ?)"
+        )
+        .bind(&date_str)
+        .bind(assets)
+        .bind(liabilities)
+        .bind(net_worth)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("Failed to backfill snapshot: {}", e))?;
+
+        // Next month
+        if month == 12 {
+            year += 1;
+            month = 1;
+        } else {
+            month += 1;
+        }
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,9 @@ pub fn run() {
             commands::analytics::get_subcategory_breakdown,
             commands::analytics::get_year_over_year_comparison,
             commands::analytics::get_analytics_dashboard,
+            // Net Worth commands
+            commands::networth::get_current_net_worth,
+            commands::networth::get_net_worth_snapshots,
             // Currency commands
             commands::currencies::get_supported_currencies,
             commands::currencies::get_primary_currency,

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod category;
 pub mod credit_card;
 pub mod currency;
 pub mod installment;
+pub mod networth;
 pub mod recurring;
 pub mod template;
 pub mod transactions;

--- a/src-tauri/src/models/networth.rs
+++ b/src-tauri/src/models/networth.rs
@@ -1,0 +1,22 @@
+// File: src-tauri/src/models/networth.rs
+use serde::{Deserialize, Serialize};
+
+/// Live net worth calculation with month-over-month change
+#[derive(Debug, Clone, Serialize)]
+pub struct NetWorthSummary {
+    pub assets: f64,
+    pub liabilities: f64,
+    pub net_worth: f64,
+    pub change_amount: f64,
+    pub change_percentage: f64,
+}
+
+/// Persisted monthly snapshot for historical chart
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetWorthSnapshot {
+    pub id: i64,
+    pub snapshot_date: String,
+    pub total_assets: f64,
+    pub total_liabilities: f64,
+    pub net_worth: f64,
+}

--- a/src/components/NetWorthCard.tsx
+++ b/src/components/NetWorthCard.tsx
@@ -1,0 +1,89 @@
+// File: src/components/NetWorthCard.tsx
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
+} from "@heroicons/react/24/outline";
+import { useCurrency } from "../hooks/useCurrency";
+import type { NetWorthSummary } from "../types/analytics";
+
+export default function NetWorthCard() {
+  const { formatAmount } = useCurrency();
+  const [data, setData] = useState<NetWorthSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadNetWorth();
+  }, []);
+
+  // Listen for refreshes after quick-add
+  useEffect(() => {
+    const handle = () => loadNetWorth();
+    window.addEventListener("refresh-net-worth", handle);
+    return () => window.removeEventListener("refresh-net-worth", handle);
+  }, []);
+
+  const loadNetWorth = async () => {
+    try {
+      const result = await invoke<NetWorthSummary>("get_current_net_worth");
+      setData(result);
+    } catch (err) {
+      console.error("Failed to load net worth:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl shadow-sm border border-indigo-400/20 p-6 mb-6 animate-pulse">
+        <div className="h-6 bg-white/20 rounded w-32 mb-3" />
+        <div className="h-10 bg-white/20 rounded w-48 mb-2" />
+        <div className="h-4 bg-white/20 rounded w-64" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const isPositive = data.change_amount >= 0;
+
+  return (
+    <div className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl shadow-sm p-6 mb-6 text-white">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-sm font-medium text-indigo-100">Net Worth</p>
+          <p className="mt-1 text-3xl font-bold">
+            {formatAmount(data.net_worth)}
+          </p>
+          <div className="mt-2 flex items-center gap-4 text-sm text-indigo-100">
+            <span>Assets: {formatAmount(data.assets)}</span>
+            <span className="text-indigo-300">|</span>
+            <span>Liabilities: {formatAmount(data.liabilities)}</span>
+          </div>
+        </div>
+
+        {/* Change indicator */}
+        <div
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium ${
+            isPositive
+              ? "bg-green-500/20 text-green-100"
+              : "bg-red-500/20 text-red-100"
+          }`}
+        >
+          {isPositive ? (
+            <ArrowTrendingUpIcon className="h-4 w-4" />
+          ) : (
+            <ArrowTrendingDownIcon className="h-4 w-4" />
+          )}
+          <span>
+            {formatAmount(Math.abs(data.change_amount))} (
+            {data.change_percentage >= 0 ? "+" : ""}
+            {data.change_percentage.toFixed(1)}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NetWorthChart.tsx
+++ b/src/components/NetWorthChart.tsx
@@ -1,0 +1,254 @@
+// File: src/components/NetWorthChart.tsx
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ComposedChart,
+  Line,
+} from "recharts";
+import { useCurrency } from "../hooks/useCurrency";
+import type { NetWorthSnapshot } from "../types/analytics";
+
+type TimeRange = "3M" | "6M" | "1Y" | "ALL";
+
+const RANGE_MONTHS: Record<TimeRange, number | null> = {
+  "3M": 3,
+  "6M": 6,
+  "1Y": 12,
+  ALL: null,
+};
+
+export default function NetWorthChart() {
+  const { formatAmount } = useCurrency();
+  const [snapshots, setSnapshots] = useState<NetWorthSnapshot[]>([]);
+  const [range, setRange] = useState<TimeRange>("1Y");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadSnapshots();
+  }, [range]);
+
+  const loadSnapshots = async () => {
+    setLoading(true);
+    try {
+      const months = RANGE_MONTHS[range];
+      const data = await invoke<NetWorthSnapshot[]>("get_net_worth_snapshots", {
+        months: months ?? 120, // 10 years max for "ALL"
+      });
+      setSnapshots(data);
+    } catch (err) {
+      console.error("Failed to load net worth snapshots:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Chart data
+  const chartData = snapshots.map((s) => ({
+    date: s.snapshot_date.substring(0, 7), // YYYY-MM
+    label: formatMonthLabel(s.snapshot_date),
+    assets: s.total_assets,
+    liabilities: s.total_liabilities,
+    netWorth: s.net_worth,
+  }));
+
+  // Summary stats
+  const netWorths = snapshots.map((s) => s.net_worth);
+  const current = netWorths.length > 0 ? netWorths[netWorths.length - 1] : 0;
+  const peak = netWorths.length > 0 ? Math.max(...netWorths) : 0;
+  const lowest = netWorths.length > 0 ? Math.min(...netWorths) : 0;
+  const average =
+    netWorths.length > 0
+      ? netWorths.reduce((a, b) => a + b, 0) / netWorths.length
+      : 0;
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const d = payload[0].payload;
+      return (
+        <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
+          <p className="font-semibold text-gray-900 dark:text-white mb-2">
+            {d.label}
+          </p>
+          <div className="space-y-1 text-sm">
+            <p>
+              <span className="text-blue-600 dark:text-blue-400">Assets:</span>{" "}
+              <span className="font-medium">{formatAmount(d.assets)}</span>
+            </p>
+            <p>
+              <span className="text-red-600 dark:text-red-400">
+                Liabilities:
+              </span>{" "}
+              <span className="font-medium">{formatAmount(d.liabilities)}</span>
+            </p>
+            <p className="border-t border-gray-200 dark:border-gray-700 pt-1 mt-1">
+              <span className="text-purple-600 dark:text-purple-400">
+                Net Worth:
+              </span>{" "}
+              <span className="font-bold">{formatAmount(d.netWorth)}</span>
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-80">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (snapshots.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-80">
+        <p className="text-gray-500 dark:text-gray-400">
+          No net worth history yet. Snapshots are generated monthly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Time range selector */}
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          {(["3M", "6M", "1Y", "ALL"] as TimeRange[]).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                range === r
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                  : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600"
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <SummaryCard label="Current" value={formatAmount(current)} />
+        <SummaryCard label="Peak" value={formatAmount(peak)} />
+        <SummaryCard label="Lowest" value={formatAmount(lowest)} />
+        <SummaryCard label="Average" value={formatAmount(average)} />
+      </div>
+
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={400}>
+        <ComposedChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+          <XAxis
+            dataKey="date"
+            tick={{ fill: "#6B7280", fontSize: 12 }}
+            tickLine={false}
+            tickFormatter={(v) => {
+              const parts = v.split("-");
+              const monthNames = [
+                "Jan",
+                "Feb",
+                "Mar",
+                "Apr",
+                "May",
+                "Jun",
+                "Jul",
+                "Aug",
+                "Sep",
+                "Oct",
+                "Nov",
+                "Dec",
+              ];
+              return monthNames[parseInt(parts[1], 10) - 1] || v;
+            }}
+          />
+          <YAxis
+            tick={{ fill: "#6B7280", fontSize: 12 }}
+            tickLine={false}
+            tickFormatter={(value) => {
+              if (Math.abs(value) >= 1000000)
+                return `${(value / 1000000).toFixed(1)}M`;
+              if (Math.abs(value) >= 1000)
+                return `${(value / 1000).toFixed(0)}k`;
+              return value.toString();
+            }}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend />
+          <Area
+            type="monotone"
+            dataKey="assets"
+            fill="#3B82F6"
+            fillOpacity={0.15}
+            stroke="#3B82F6"
+            strokeWidth={1.5}
+            name="Assets"
+          />
+          <Area
+            type="monotone"
+            dataKey="liabilities"
+            fill="#EF4444"
+            fillOpacity={0.1}
+            stroke="#EF4444"
+            strokeWidth={1.5}
+            name="Liabilities"
+          />
+          <Line
+            type="monotone"
+            dataKey="netWorth"
+            stroke="#8B5CF6"
+            strokeWidth={3}
+            dot={{ fill: "#8B5CF6", strokeWidth: 2, r: 3 }}
+            activeDot={{ r: 6 }}
+            name="Net Worth"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
+      <p className="text-xs font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-bold text-gray-900 dark:text-white">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function formatMonthLabel(dateStr: string): string {
+  const monthNames = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  const parts = dateStr.split("-");
+  const monthIdx = parseInt(parts[1], 10) - 1;
+  return `${monthNames[monthIdx]} ${parts[0]}`;
+}

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,16 @@
+// File: src/types/analytics.ts
+export interface NetWorthSummary {
+  assets: number;
+  liabilities: number;
+  net_worth: number;
+  change_amount: number;
+  change_percentage: number;
+}
+
+export interface NetWorthSnapshot {
+  id: number;
+  snapshot_date: string;
+  total_assets: number;
+  total_liabilities: number;
+  net_worth: number;
+}

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -11,6 +11,7 @@ import StatCard from "../components/StatCard";
 import CategorySpendingChart from "../components/CategorySpendingChart";
 import Calendar from "../components/Calendar";
 import QuickAddBar from "../components/QuickAddBar";
+import NetWorthCard from "../components/NetWorthCard";
 import type { AccountWithBalance } from "../types/account";
 import type { TransactionWithDetails } from "../types/transaction";
 
@@ -59,8 +60,7 @@ export default function DashboardView() {
       let prevEndDate: string;
 
       switch (comparisonMode) {
-        case "month":
-          // Previous month
+        case "month": {
           const prevFirstDay = new Date(
             now.getFullYear(),
             now.getMonth() - 1,
@@ -70,9 +70,8 @@ export default function DashboardView() {
           prevStartDate = prevFirstDay.toISOString().split("T")[0];
           prevEndDate = prevLastDay.toISOString().split("T")[0];
           break;
-
-        case "year":
-          // Same month last year
+        }
+        case "year": {
           const prevYearFirstDay = new Date(
             now.getFullYear() - 1,
             now.getMonth(),
@@ -86,9 +85,8 @@ export default function DashboardView() {
           prevStartDate = prevYearFirstDay.toISOString().split("T")[0];
           prevEndDate = prevYearLastDay.toISOString().split("T")[0];
           break;
-
-        case "quarter":
-          // Previous quarter (3 months ago)
+        }
+        case "quarter": {
           const prevQuarterFirstDay = new Date(
             now.getFullYear(),
             now.getMonth() - 3,
@@ -102,6 +100,7 @@ export default function DashboardView() {
           prevStartDate = prevQuarterFirstDay.toISOString().split("T")[0];
           prevEndDate = prevQuarterLastDay.toISOString().split("T")[0];
           break;
+        }
       }
 
       const [accountsData, summaryData, prevSummaryData, transactionsData] =
@@ -133,9 +132,10 @@ export default function DashboardView() {
     loadDashboardData();
   }, [loadDashboardData]);
 
-  // Callback when QuickAddBar saves a transaction — refresh dashboard data
   const handleTransactionAdded = useCallback(() => {
     loadDashboardData();
+    // Also refresh NetWorthCard
+    window.dispatchEvent(new CustomEvent("refresh-net-worth"));
   }, [loadDashboardData]);
 
   const totalBalance = accounts.reduce(
@@ -143,7 +143,6 @@ export default function DashboardView() {
     0,
   );
 
-  // Calculate percentage changes
   const incomeChange =
     summary && prevSummary && prevSummary.total_income > 0
       ? ((summary.total_income - prevSummary.total_income) /
@@ -158,7 +157,6 @@ export default function DashboardView() {
         100
       : 0;
 
-  // Get comparison label
   const getComparisonLabel = () => {
     switch (comparisonMode) {
       case "month":
@@ -219,6 +217,9 @@ export default function DashboardView() {
 
       {/* Quick Add Bar */}
       <QuickAddBar onTransactionAdded={handleTransactionAdded} />
+
+      {/* Net Worth Card */}
+      <NetWorthCard />
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
@@ -323,9 +324,7 @@ export default function DashboardView() {
       {/* Tab Content */}
       {activeTab === "overview" ? (
         <>
-          {/* Two Column Layout */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
-            {/* Category Spending Chart */}
             <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
                 Spending by Category
@@ -336,8 +335,6 @@ export default function DashboardView() {
                 transactionType="EXPENSE"
               />
             </div>
-
-            {/* Income Sources Chart */}
             <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
                 Income Sources
@@ -350,7 +347,6 @@ export default function DashboardView() {
             </div>
           </div>
 
-          {/* Recent Transactions */}
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
@@ -431,7 +427,6 @@ export default function DashboardView() {
           </div>
         </>
       ) : (
-        /* Calendar View */
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
           <Calendar />
         </div>

--- a/src/views/ReportsView.tsx
+++ b/src/views/ReportsView.tsx
@@ -6,6 +6,7 @@ import {
   TableCellsIcon,
   ArrowsRightLeftIcon,
   BanknotesIcon,
+  ScaleIcon,
 } from "@heroicons/react/24/outline";
 import ReportFilters from "../components/ReportFilters";
 import TrendChart from "../components/TrendChart";
@@ -14,6 +15,7 @@ import ReportTable from "../components/ReportTable";
 import ExportMenu from "../components/ExportMenu";
 import CategorySpendingChart from "../components/CategorySpendingChart";
 import AccountActivityCard from "../components/AccountActivityCard";
+import NetWorthChart from "../components/NetWorthChart";
 import type {
   ReportFilters as ReportFiltersType,
   MonthlyTrend,
@@ -25,6 +27,7 @@ import type { AccountWithBalance } from "../types/account";
 type ReportTab =
   | "overview"
   | "trends"
+  | "net-worth"
   | "categories"
   | "accounts"
   | "transactions";
@@ -75,7 +78,6 @@ export default function ReportsView() {
       setTransactions(transactionsData);
       setAccounts(accountsData);
 
-      // Load comparison separately
       const comparisonData = await loadComparison();
       setComparison(comparisonData);
     } catch (error) {
@@ -87,11 +89,9 @@ export default function ReportsView() {
 
   const loadComparison = async (): Promise<PeriodComparison | null> => {
     try {
-      // Current period
       const currentStart = filters.startDate;
       const currentEnd = filters.endDate;
 
-      // Previous period (same duration, shifted back)
       const startDate = new Date(filters.startDate);
       const endDate = new Date(filters.endDate);
       const duration = endDate.getTime() - startDate.getTime();
@@ -163,7 +163,6 @@ export default function ReportsView() {
     setFilters(newFilters);
   };
 
-  // Convert ReportFilters to ExportFilter format
   const getExportFilters = () => ({
     start_date: filters.startDate,
     end_date: filters.endDate,
@@ -175,6 +174,7 @@ export default function ReportsView() {
   const tabs = [
     { id: "overview" as ReportTab, label: "Overview", icon: ChartBarIcon },
     { id: "trends" as ReportTab, label: "Trends", icon: ArrowsRightLeftIcon },
+    { id: "net-worth" as ReportTab, label: "Net Worth", icon: ScaleIcon },
     { id: "categories" as ReportTab, label: "Categories", icon: ChartBarIcon },
     { id: "accounts" as ReportTab, label: "Accounts", icon: BanknotesIcon },
     {
@@ -223,7 +223,7 @@ export default function ReportsView() {
       </div>
 
       {/* Tab Content */}
-      {loading ? (
+      {loading && activeTab !== "net-worth" ? (
         <div className="flex items-center justify-center h-96">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
         </div>
@@ -232,10 +232,8 @@ export default function ReportsView() {
           {/* Overview Tab */}
           {activeTab === "overview" && (
             <div className="space-y-8">
-              {/* Period Comparison */}
               {comparison && <ComparisonCard comparison={comparison} />}
 
-              {/* Quick Stats Grid */}
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <div className="bg-white dark:bg-gray-800 rounded-xl p-6 border border-gray-200 dark:border-gray-700">
                   <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -267,7 +265,7 @@ export default function ReportsView() {
                   </p>
                   <p
                     className={`text-2xl font-bold mt-1 ${
-                      (comparison?.currentPeriod.netSavings || 0) >= 0
+                      (comparison?.currentPeriod.netSavings ?? 0) >= 0
                         ? "text-blue-600 dark:text-blue-400"
                         : "text-orange-600 dark:text-orange-400"
                     }`}
@@ -289,7 +287,6 @@ export default function ReportsView() {
                 </div>
               </div>
 
-              {/* Charts Row */}
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <div className="bg-white dark:bg-gray-800 rounded-xl p-6 border border-gray-200 dark:border-gray-700">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
@@ -325,7 +322,6 @@ export default function ReportsView() {
                 <TrendChart data={trends} />
               </div>
 
-              {/* Monthly Summary Table */}
               <div className="bg-white dark:bg-gray-800 rounded-xl p-6 border border-gray-200 dark:border-gray-700">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
                   Monthly Summary
@@ -408,6 +404,16 @@ export default function ReportsView() {
                   </table>
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Net Worth Tab */}
+          {activeTab === "net-worth" && (
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 border border-gray-200 dark:border-gray-700">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                Net Worth Over Time
+              </h3>
+              <NetWorthChart />
             </div>
           )}
 


### PR DESCRIPTION
…s chart

- Add net_worth_snapshots migration, backfill on first launch
- Backend: get_current_net_worth, get_net_worth_snapshots commands
- Generate/update snapshot on every app startup
- NetWorthCard on Dashboard with month-over-month change
- NetWorthChart tab in Reports with area chart and time range selector

Closes #26