### PR TITLE
feat(auto-backup): add Scheduled Auto-Backup with zip restore & photo…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1016,6 +1016,7 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2212,6 +2213,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tokio",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -3368,7 +3370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601548259832652f6fb539d75df1f8c44820635230bb3b9f5e3b87283541cd3b"
 dependencies = [
  "regex",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6045,6 +6047,26 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,3 +32,4 @@ dirs = "5.0"
 bcrypt = "0.16"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "bmp", "gif"] }
 rust_xlsxwriter = "0.72.0"
+zip = { version = "4.1", default-features = false, features = ["deflate"] }

--- a/src-tauri/migrations/20240210000001_auto_backup_settings.sql
+++ b/src-tauri/migrations/20240210000001_auto_backup_settings.sql
@@ -1,0 +1,9 @@
+-- File: src-tauri/migrations/20240210000001_auto_backup_settings.sql
+-- Auto-backup settings stored in the existing app_settings key-value table
+
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_enabled', 'false');
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_frequency', 'WEEKLY');
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_path', '');
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_retention', '5');
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_include_photos', 'false');
+INSERT OR IGNORE INTO app_settings (key, value) VALUES ('auto_backup_last_run', '');

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod installments;
 pub mod networth;
 pub mod photos;
 pub mod recurring;
+pub mod scheduled_backup;
 pub mod security;
 pub mod settings;
 pub mod templates;

--- a/src-tauri/src/commands/scheduled_backup.rs
+++ b/src-tauri/src/commands/scheduled_backup.rs
@@ -1,0 +1,809 @@
+// File: src-tauri/src/commands/scheduled_backup.rs
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use tauri::{Manager, State};
+use zip::write::SimpleFileOptions;
+
+// ======================== TYPES ========================
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BackupSettings {
+    pub auto_backup_enabled: bool,
+    pub auto_backup_frequency: String, // DAILY, WEEKLY, MONTHLY
+    pub auto_backup_path: String,
+    pub auto_backup_retention: i64,
+    pub auto_backup_include_photos: bool,
+    pub auto_backup_last_run: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackupStatus {
+    pub last_backup_date: Option<String>,
+    pub next_due_date: Option<String>,
+    pub backup_count: i64,
+    pub is_overdue: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackupResult {
+    pub success: bool,
+    pub file_path: String,
+    pub file_size_bytes: u64,
+    pub photos_included: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ZipRestoreResult {
+    pub success: bool,
+    pub accounts_restored: i64,
+    pub categories_restored: i64,
+    pub transactions_restored: i64,
+    pub budgets_restored: i64,
+    pub photos_restored: i64,
+}
+
+// ======================== COMMANDS ========================
+
+/// Read all auto-backup settings from app_settings
+#[tauri::command]
+pub async fn get_backup_settings(pool: State<'_, SqlitePool>) -> Result<BackupSettings, String> {
+    get_backup_settings_internal(pool.inner()).await
+}
+
+/// Save all auto-backup settings to app_settings
+#[tauri::command]
+pub async fn update_backup_settings(
+    pool: State<'_, SqlitePool>,
+    settings: BackupSettings,
+) -> Result<(), String> {
+    let pairs = vec![
+        ("auto_backup_enabled", settings.auto_backup_enabled.to_string()),
+        ("auto_backup_frequency", settings.auto_backup_frequency),
+        ("auto_backup_path", settings.auto_backup_path),
+        ("auto_backup_retention", settings.auto_backup_retention.to_string()),
+        ("auto_backup_include_photos", settings.auto_backup_include_photos.to_string()),
+        ("auto_backup_last_run", settings.auto_backup_last_run),
+    ];
+
+    for (key, value) in pairs {
+        sqlx::query(
+            "INSERT INTO app_settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(pool.inner())
+        .await
+        .map_err(|e| format!("Failed to update setting '{}': {}", key, e))?;
+    }
+
+    Ok(())
+}
+
+/// Get the current backup status (for display in Settings UI)
+#[tauri::command]
+pub async fn get_backup_status(
+    pool: State<'_, SqlitePool>,
+) -> Result<BackupStatus, String> {
+    let settings = get_backup_settings_internal(pool.inner()).await?;
+
+    let last_backup_date = if settings.auto_backup_last_run.is_empty() {
+        None
+    } else {
+        Some(settings.auto_backup_last_run.clone())
+    };
+
+    let next_due_date = if settings.auto_backup_last_run.is_empty() || !settings.auto_backup_enabled {
+        None
+    } else {
+        calculate_next_due(&settings.auto_backup_last_run, &settings.auto_backup_frequency)
+    };
+
+    let backup_count = if settings.auto_backup_path.is_empty() {
+        0
+    } else {
+        count_backup_files(&settings.auto_backup_path)
+    };
+
+    let is_overdue = check_is_overdue(
+        &settings.auto_backup_last_run,
+        &settings.auto_backup_frequency,
+        settings.auto_backup_enabled,
+    );
+
+    Ok(BackupStatus {
+        last_backup_date,
+        next_due_date,
+        backup_count,
+        is_overdue,
+    })
+}
+
+/// Manually trigger an auto-backup from the Settings UI
+#[tauri::command]
+pub async fn run_auto_backup_now(
+    app_handle: tauri::AppHandle,
+    pool: State<'_, SqlitePool>,
+) -> Result<BackupResult, String> {
+    let settings = get_backup_settings_internal(pool.inner()).await?;
+
+    if settings.auto_backup_path.is_empty() {
+        return Err("No backup path configured. Please select a backup folder first.".to_string());
+    }
+
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+
+    let result = perform_backup(
+        pool.inner(),
+        &settings.auto_backup_path,
+        settings.auto_backup_include_photos,
+        &app_data_dir,
+    )
+    .await?;
+
+    // Update last run timestamp
+    set_setting(pool.inner(), "auto_backup_last_run", &chrono::Utc::now().to_rfc3339()).await?;
+
+    // Apply retention
+    apply_retention(&settings.auto_backup_path, settings.auto_backup_retention)?;
+
+    Ok(result)
+}
+
+/// Called from lib.rs setup — runs silently on app startup.
+/// Returns Some(message) if backup was performed, None otherwise.
+#[tauri::command]
+pub async fn check_and_run_auto_backup(
+    app_handle: tauri::AppHandle,
+    pool: State<'_, SqlitePool>,
+) -> Result<Option<String>, String> {
+    check_and_run_auto_backup_internal(pool.inner(), &app_handle).await
+}
+
+/// Restore from a .zip backup file.
+/// Extracts backup.json → restores DB via existing restore logic.
+/// If photos/ directory exists in zip → copies photos back to app photos dir
+/// and re-inserts transaction_photos records with remapped transaction IDs.
+#[tauri::command]
+pub async fn restore_from_zip_backup(
+    app_handle: tauri::AppHandle,
+    pool: State<'_, SqlitePool>,
+    zip_path: String,
+) -> Result<ZipRestoreResult, String> {
+    println!("=== restore_from_zip_backup called ===");
+    println!("Zip path: {}", zip_path);
+
+    // 1. Open the zip file
+    let file = fs::File::open(&zip_path)
+        .map_err(|e| format!("Failed to open zip file: {}", e))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|e| format!("Failed to read zip archive: {}", e))?;
+
+    // 2. Extract backup.json
+    let backup_json = {
+        let mut backup_file = archive
+            .by_name("backup.json")
+            .map_err(|_| "Zip does not contain backup.json — not a valid Money Manager backup".to_string())?;
+        let mut contents = String::new();
+        backup_file
+            .read_to_string(&mut contents)
+            .map_err(|e| format!("Failed to read backup.json from zip: {}", e))?;
+        contents
+    };
+
+    // 3. Parse the backup JSON
+    let backup: serde_json::Value = serde_json::from_str(&backup_json)
+        .map_err(|e| format!("Invalid backup.json format: {}", e))?;
+
+    let version = backup.get("version").and_then(|v| v.as_str()).unwrap_or("unknown");
+    if version != "1.0" {
+        return Err(format!("Unsupported backup version: {}. Expected 1.0", version));
+    }
+
+    // 4. Restore the database using the existing restore logic
+    // We call restore_from_backup via the pool directly
+    let restore_result = crate::commands::settings::restore_from_backup_internal(
+        pool.inner(), &backup_json
+    ).await?;
+
+    // 5. Restore photos from the zip (if present)
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+    let photos_dir = app_data_dir.join("photos");
+
+    let mut photos_restored: i64 = 0;
+
+    // Re-open archive since ZipArchive borrows the file
+    let file2 = fs::File::open(&zip_path)
+        .map_err(|e| format!("Failed to re-open zip file: {}", e))?;
+    let mut archive2 = zip::ZipArchive::new(file2)
+        .map_err(|e| format!("Failed to re-read zip archive: {}", e))?;
+
+    for i in 0..archive2.len() {
+        let mut entry = archive2.by_index(i)
+            .map_err(|e| format!("Failed to read zip entry: {}", e))?;
+
+        let entry_name = entry.name().to_string();
+
+        // Check if this is a photo file inside the photos/ directory
+        if entry_name.starts_with("photos/") && entry_name.len() > 7 && !entry.is_dir() {
+            let filename = entry_name.strip_prefix("photos/").unwrap_or(&entry_name);
+            
+            // Skip subdirectory paths — only restore direct files
+            if filename.contains('/') {
+                continue;
+            }
+
+            // Create photos directory if needed
+            fs::create_dir_all(&photos_dir)
+                .map_err(|e| format!("Failed to create photos directory: {}", e))?;
+
+            // Extract the photo file
+            let dest_path = photos_dir.join(filename);
+            let mut output = fs::File::create(&dest_path)
+                .map_err(|e| format!("Failed to create photo file {}: {}", filename, e))?;
+            std::io::copy(&mut entry, &mut output)
+                .map_err(|e| format!("Failed to extract photo {}: {}", filename, e))?;
+
+            photos_restored += 1;
+            println!("Restored photo: {}", filename);
+        }
+    }
+
+    // 6. Restore transaction_photos records if present in backup JSON
+    let data = backup.get("data");
+    if let Some(photos_data) = data.and_then(|d| d.get("transaction_photos")).and_then(|v| v.as_array()) {
+        // We need to remap old transaction IDs to new ones.
+        // Since restore_from_backup_internal returns the result but not the ID maps,
+        // we'll re-insert photos by matching filenames to the photos on disk.
+        // The simplest approach: insert records with the new transaction IDs.
+        // But we don't have the mapping here. So we'll match by the original transaction's
+        // unique characteristics (date + amount + account) or simply insert with
+        // a filename-based approach.
+        
+        // Actually, since the full restore replaces all data with sequential new IDs,
+        // and our backup stores transaction_photos with old_transaction_id,
+        // we need to build a mapping. The restore logic creates transactions in order,
+        // so old_id N maps to new sequential ID.
+        // Let's query all transactions and build the map from backup data.
+        
+        let txn_data = data.and_then(|d| d.get("transactions")).and_then(|v| v.as_array());
+        
+        if let Some(transactions) = txn_data {
+            // Build old_id → position map (0-indexed order of insertion)
+            let old_ids: Vec<i64> = transactions.iter().map(|t| {
+                let txn = t.get("transaction").unwrap_or(t);
+                txn.get("id").and_then(|v| v.as_i64()).unwrap_or(0)
+            }).collect();
+
+            // Fetch all new transaction IDs in insertion order
+            let new_txn_rows = sqlx::query(
+                "SELECT id FROM transactions ORDER BY id ASC"
+            )
+            .fetch_all(pool.inner())
+            .await
+            .map_err(|e| format!("Failed to fetch new transaction IDs: {}", e))?;
+
+            let new_ids: Vec<i64> = new_txn_rows.iter().map(|r| r.get::<i64, _>("id")).collect();
+
+            // Build old → new map
+            let mut txn_id_map: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+            for (idx, old_id) in old_ids.iter().enumerate() {
+                if idx < new_ids.len() {
+                    txn_id_map.insert(*old_id, new_ids[idx]);
+                }
+            }
+
+            // Now insert transaction_photos with remapped IDs
+            for photo in photos_data {
+                let old_txn_id = photo.get("transaction_id").and_then(|v| v.as_i64()).unwrap_or(0);
+                let filename = photo.get("filename").and_then(|v| v.as_str()).unwrap_or("");
+                
+                if filename.is_empty() || old_txn_id == 0 {
+                    continue;
+                }
+
+                let new_txn_id = txn_id_map.get(&old_txn_id).copied().unwrap_or(old_txn_id);
+
+                // Only insert if the photo file exists on disk
+                let photo_path = photos_dir.join(filename);
+                if photo_path.exists() {
+                    let _ = sqlx::query(
+                        "INSERT OR IGNORE INTO transaction_photos (transaction_id, filename) VALUES (?, ?)"
+                    )
+                    .bind(new_txn_id)
+                    .bind(filename)
+                    .execute(pool.inner())
+                    .await;
+                }
+            }
+        }
+    }
+
+    println!("Zip restore complete: {} accounts, {} categories, {} transactions, {} budgets, {} photos",
+        restore_result.accounts_restored,
+        restore_result.categories_restored,
+        restore_result.transactions_restored,
+        restore_result.budgets_restored,
+        photos_restored,
+    );
+
+    Ok(ZipRestoreResult {
+        success: true,
+        accounts_restored: restore_result.accounts_restored,
+        categories_restored: restore_result.categories_restored,
+        transactions_restored: restore_result.transactions_restored,
+        budgets_restored: restore_result.budgets_restored,
+        photos_restored,
+    })
+}
+
+/// Internal version callable without State wrapper (for lib.rs startup)
+pub async fn check_and_run_auto_backup_internal(
+    pool: &SqlitePool,
+    app_handle: &tauri::AppHandle,
+) -> Result<Option<String>, String> {
+    let settings = get_backup_settings_internal(pool).await?;
+
+    // Skip if disabled
+    if !settings.auto_backup_enabled {
+        return Ok(None);
+    }
+
+    // Skip if no path configured
+    if settings.auto_backup_path.is_empty() {
+        return Ok(None);
+    }
+
+    // Check if backup is due
+    if !is_backup_due(&settings.auto_backup_last_run, &settings.auto_backup_frequency) {
+        return Ok(None);
+    }
+
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+
+    // Perform the backup
+    let result = perform_backup(
+        pool,
+        &settings.auto_backup_path,
+        settings.auto_backup_include_photos,
+        &app_data_dir,
+    )
+    .await?;
+
+    // Update last run
+    set_setting(pool, "auto_backup_last_run", &chrono::Utc::now().to_rfc3339()).await?;
+
+    // Apply retention
+    apply_retention(&settings.auto_backup_path, settings.auto_backup_retention)?;
+
+    Ok(Some(format!(
+        "Backup completed: {} ({} bytes)",
+        result.file_path, result.file_size_bytes
+    )))
+}
+
+// ======================== INTERNAL HELPERS ========================
+
+async fn get_backup_settings_internal(pool: &SqlitePool) -> Result<BackupSettings, String> {
+    let rows = sqlx::query(
+        "SELECT key, value FROM app_settings WHERE key LIKE 'auto_backup_%'"
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to read backup settings: {}", e))?;
+
+    let mut settings = BackupSettings {
+        auto_backup_enabled: false,
+        auto_backup_frequency: "WEEKLY".to_string(),
+        auto_backup_path: String::new(),
+        auto_backup_retention: 5,
+        auto_backup_include_photos: false,
+        auto_backup_last_run: String::new(),
+    };
+
+    for row in &rows {
+        let key: String = row.get("key");
+        let value: String = row.get("value");
+        match key.as_str() {
+            "auto_backup_enabled" => settings.auto_backup_enabled = value == "true",
+            "auto_backup_frequency" => settings.auto_backup_frequency = value,
+            "auto_backup_path" => settings.auto_backup_path = value,
+            "auto_backup_retention" => {
+                settings.auto_backup_retention = value.parse().unwrap_or(5)
+            }
+            "auto_backup_include_photos" => {
+                settings.auto_backup_include_photos = value == "true"
+            }
+            "auto_backup_last_run" => settings.auto_backup_last_run = value,
+            _ => {}
+        }
+    }
+
+    Ok(settings)
+}
+
+async fn set_setting(pool: &SqlitePool, key: &str, value: &str) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO app_settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("Failed to update setting '{}': {}", key, e))?;
+    Ok(())
+}
+
+/// Core backup logic: creates a zip file containing the database JSON export
+/// and optionally the photos directory.
+async fn perform_backup(
+    pool: &SqlitePool,
+    backup_path: &str,
+    include_photos: bool,
+    app_data_dir: &Path,
+) -> Result<BackupResult, String> {
+    // Ensure backup directory exists
+    fs::create_dir_all(backup_path)
+        .map_err(|e| format!("Failed to create backup directory: {}", e))?;
+
+    // Generate filename
+    let now = chrono::Local::now();
+    let filename = format!("money_manager_backup_{}.zip", now.format("%Y-%m-%d_%H%M"));
+    let zip_path = PathBuf::from(backup_path).join(&filename);
+
+    // Generate backup JSON (reuse the same logic as export_full_backup)
+    let backup_json = generate_backup_json(pool).await?;
+
+    // Create the zip file
+    let file = fs::File::create(&zip_path)
+        .map_err(|e| format!("Failed to create zip file: {}", e))?;
+
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+
+    // Add backup.json
+    zip.start_file("backup.json", options)
+        .map_err(|e| format!("Failed to add backup.json to zip: {}", e))?;
+    zip.write_all(backup_json.as_bytes())
+        .map_err(|e| format!("Failed to write backup data: {}", e))?;
+
+    // Optionally add photos
+    let mut photos_included = false;
+    if include_photos {
+        let photos_dir = app_data_dir.join("photos");
+        if photos_dir.exists() && photos_dir.is_dir() {
+            add_directory_to_zip(&mut zip, &photos_dir, "photos", &options)?;
+            photos_included = true;
+        }
+    }
+
+    zip.finish()
+        .map_err(|e| format!("Failed to finalize zip: {}", e))?;
+
+    // Get file size
+    let file_size = fs::metadata(&zip_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let file_path_str = zip_path.to_str().unwrap_or("").to_string();
+
+    println!("Auto-backup created: {} ({} bytes, photos: {})", file_path_str, file_size, photos_included);
+
+    Ok(BackupResult {
+        success: true,
+        file_path: file_path_str,
+        file_size_bytes: file_size,
+        photos_included,
+    })
+}
+
+/// Generate JSON backup data (same structure as export_full_backup)
+async fn generate_backup_json(pool: &SqlitePool) -> Result<String, String> {
+    // Accounts
+    let account_rows = sqlx::query(
+        "SELECT id, group_id, name, initial_balance, currency, created_at FROM accounts ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to fetch accounts: {}", e))?;
+
+    let accounts: Vec<serde_json::Value> = account_rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "id": row.get::<i64, _>("id"),
+                "group_id": row.get::<i64, _>("group_id"),
+                "name": row.get::<String, _>("name"),
+                "initial_balance": row.get::<f64, _>("initial_balance"),
+                "currency": row.get::<String, _>("currency"),
+                "created_at": row.get::<String, _>("created_at")
+            })
+        })
+        .collect();
+
+    // Categories
+    let category_rows = sqlx::query("SELECT id, name, type, parent_id FROM categories ORDER BY name")
+        .fetch_all(pool)
+        .await
+        .map_err(|e| format!("Failed to fetch categories: {}", e))?;
+
+    let categories: Vec<serde_json::Value> = category_rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "id": row.get::<i64, _>("id"),
+                "name": row.get::<String, _>("name"),
+                "type": row.get::<String, _>("type"),
+                "parent_id": row.get::<Option<i64>, _>("parent_id")
+            })
+        })
+        .collect();
+
+    // Transactions
+    let txn_rows = sqlx::query(
+        "SELECT t.id, t.date, t.type, t.amount, t.account_id, t.to_account_id,
+                t.category_id, t.memo, t.photo_path, t.created_at,
+                a.name as account_name,
+                ta.name as to_account_name,
+                c.name as category_name
+         FROM transactions t
+         INNER JOIN accounts a ON t.account_id = a.id
+         LEFT JOIN accounts ta ON t.to_account_id = ta.id
+         LEFT JOIN categories c ON t.category_id = c.id
+         ORDER BY t.date DESC, t.created_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to fetch transactions: {}", e))?;
+
+    let transactions: Vec<serde_json::Value> = txn_rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "transaction": {
+                    "id": row.get::<i64, _>("id"),
+                    "date": row.get::<String, _>("date"),
+                    "transaction_type": row.get::<String, _>("type"),
+                    "amount": row.get::<f64, _>("amount"),
+                    "account_id": row.get::<i64, _>("account_id"),
+                    "to_account_id": row.get::<Option<i64>, _>("to_account_id"),
+                    "category_id": row.get::<Option<i64>, _>("category_id"),
+                    "memo": row.get::<Option<String>, _>("memo"),
+                    "photo_path": row.get::<Option<String>, _>("photo_path"),
+                    "created_at": row.get::<String, _>("created_at")
+                },
+                "account_name": row.get::<String, _>("account_name"),
+                "to_account_name": row.get::<Option<String>, _>("to_account_name"),
+                "category_name": row.get::<Option<String>, _>("category_name")
+            })
+        })
+        .collect();
+
+    // Budgets
+    let budget_rows =
+        sqlx::query("SELECT id, category_id, amount, period, start_date FROM budgets ORDER BY id")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("Failed to fetch budgets: {}", e))?;
+
+    let budgets: Vec<serde_json::Value> = budget_rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "id": row.get::<i64, _>("id"),
+                "category_id": row.get::<i64, _>("category_id"),
+                "amount": row.get::<f64, _>("amount"),
+                "period": row.get::<String, _>("period"),
+                "start_date": row.get::<String, _>("start_date")
+            })
+        })
+        .collect();
+
+    // Transaction Photos (for zip backup restore)
+    let photo_rows = sqlx::query(
+        "SELECT id, transaction_id, filename, created_at FROM transaction_photos ORDER BY id"
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let transaction_photos: Vec<serde_json::Value> = photo_rows
+        .iter()
+        .map(|row| {
+            serde_json::json!({
+                "id": row.get::<i64, _>("id"),
+                "transaction_id": row.get::<i64, _>("transaction_id"),
+                "filename": row.get::<String, _>("filename"),
+                "created_at": row.get::<String, _>("created_at")
+            })
+        })
+        .collect();
+
+    let backup = serde_json::json!({
+        "version": "1.0",
+        "exported_at": chrono::Utc::now().to_rfc3339(),
+        "data": {
+            "accounts": accounts,
+            "categories": categories,
+            "transactions": transactions,
+            "budgets": budgets,
+            "transaction_photos": transaction_photos
+        }
+    });
+
+    serde_json::to_string_pretty(&backup)
+        .map_err(|e| format!("Failed to serialize backup: {}", e))
+}
+
+/// Recursively add a directory's contents to a zip file
+fn add_directory_to_zip(
+    zip: &mut zip::ZipWriter<fs::File>,
+    source_dir: &Path,
+    prefix: &str,
+    options: &SimpleFileOptions,
+) -> Result<(), String> {
+    let entries = fs::read_dir(source_dir)
+        .map_err(|e| format!("Failed to read directory {}: {}", source_dir.display(), e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_str = name.to_str().unwrap_or("");
+        let zip_path = format!("{}/{}", prefix, name_str);
+
+        if path.is_file() {
+            zip.start_file(&zip_path, *options)
+                .map_err(|e| format!("Failed to add file to zip: {}", e))?;
+            let data = fs::read(&path)
+                .map_err(|e| format!("Failed to read file {}: {}", path.display(), e))?;
+            zip.write_all(&data)
+                .map_err(|e| format!("Failed to write file to zip: {}", e))?;
+        } else if path.is_dir() {
+            add_directory_to_zip(zip, &path, &zip_path, options)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete oldest backup files when count exceeds the retention limit
+fn apply_retention(backup_path: &str, max_count: i64) -> Result<(), String> {
+    if max_count <= 0 {
+        return Ok(());
+    }
+
+    let dir = Path::new(backup_path);
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    let mut backups: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
+
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read backup directory: {}", e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let path = entry.path();
+        let name = entry.file_name().to_str().unwrap_or("").to_string();
+
+        // Only consider our backup files
+        if name.starts_with("money_manager_backup_") && name.ends_with(".zip") {
+            if let Ok(metadata) = fs::metadata(&path) {
+                if let Ok(modified) = metadata.modified() {
+                    backups.push((path, modified));
+                }
+            }
+        }
+    }
+
+    // Sort by modification time (newest first)
+    backups.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Delete excess backups
+    if backups.len() as i64 > max_count {
+        for (path, _) in &backups[max_count as usize..] {
+            match fs::remove_file(path) {
+                Ok(_) => println!("Retention: deleted old backup {}", path.display()),
+                Err(e) => println!("Warning: failed to delete {}: {}", path.display(), e),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Count backup zip files in the configured directory
+fn count_backup_files(backup_path: &str) -> i64 {
+    let dir = Path::new(backup_path);
+    if !dir.exists() {
+        return 0;
+    }
+
+    fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    let name = e.file_name().to_str().unwrap_or("").to_string();
+                    name.starts_with("money_manager_backup_") && name.ends_with(".zip")
+                })
+                .count() as i64
+        })
+        .unwrap_or(0)
+}
+
+/// Check if a backup is due based on frequency and last run
+fn is_backup_due(last_run: &str, frequency: &str) -> bool {
+    if last_run.is_empty() {
+        return true; // Never run before
+    }
+
+    let last = match chrono::DateTime::parse_from_rfc3339(last_run) {
+        Ok(dt) => dt.with_timezone(&chrono::Utc),
+        Err(_) => return true, // Can't parse, assume due
+    };
+
+    let now = chrono::Utc::now();
+    let elapsed = now.signed_duration_since(last);
+
+    match frequency {
+        "DAILY" => elapsed.num_hours() >= 24,
+        "WEEKLY" => elapsed.num_days() >= 7,
+        "MONTHLY" => elapsed.num_days() >= 30,
+        _ => elapsed.num_days() >= 7, // Default to weekly
+    }
+}
+
+/// Calculate the next due date based on last run and frequency
+fn calculate_next_due(last_run: &str, frequency: &str) -> Option<String> {
+    let last = chrono::DateTime::parse_from_rfc3339(last_run).ok()?;
+
+    let duration = match frequency {
+        "DAILY" => chrono::Duration::days(1),
+        "WEEKLY" => chrono::Duration::days(7),
+        "MONTHLY" => chrono::Duration::days(30),
+        _ => chrono::Duration::days(7),
+    };
+
+    let next = last + duration;
+    Some(next.to_rfc3339())
+}
+
+/// Check if the backup is overdue (> 2× the configured frequency)
+fn check_is_overdue(last_run: &str, frequency: &str, enabled: bool) -> bool {
+    if !enabled || last_run.is_empty() {
+        return false;
+    }
+
+    let last = match chrono::DateTime::parse_from_rfc3339(last_run) {
+        Ok(dt) => dt.with_timezone(&chrono::Utc),
+        Err(_) => return false,
+    };
+
+    let now = chrono::Utc::now();
+    let elapsed = now.signed_duration_since(last);
+
+    match frequency {
+        "DAILY" => elapsed.num_hours() >= 48,
+        "WEEKLY" => elapsed.num_days() >= 14,
+        "MONTHLY" => elapsed.num_days() >= 60,
+        _ => elapsed.num_days() >= 14,
+    }
+}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -12,6 +12,14 @@ pub async fn restore_from_backup(
     pool: State<'_, SqlitePool>,
     backup_json: String,
 ) -> Result<RestoreResult, String> {
+    restore_from_backup_internal(pool.inner(), &backup_json).await
+}
+
+/// Internal version without State wrapper — callable from scheduled_backup.rs
+pub async fn restore_from_backup_internal(
+    pool: &SqlitePool,
+    backup_json: &str,
+) -> Result<RestoreResult, String> {
     // 1. Parse and validate backup JSON
     let backup: serde_json::Value = serde_json::from_str(&backup_json)
         .map_err(|e| format!("Invalid backup file format: {}", e))?;
@@ -54,7 +62,6 @@ pub async fn restore_from_backup(
 
     // 2. Begin transaction for atomic restore
     let mut tx = pool
-        .inner()
         .begin()
         .await
         .map_err(|e| format!("Failed to begin transaction: {}", e))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,7 +32,26 @@ pub fn run() {
                     .expect("Failed to initialize database")
             });
 
-            app.manage(pool);
+            app.manage(pool.clone());
+
+            // Auto-backup check: runs silently on startup, never blocks UI
+            let app_handle = app.handle().clone();
+            let pool_for_backup = pool.clone();
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                rt.block_on(async {
+                    match commands::scheduled_backup::check_and_run_auto_backup_internal(
+                        &pool_for_backup,
+                        &app_handle,
+                    )
+                    .await
+                    {
+                        Ok(Some(msg)) => println!("Auto-backup: {}", msg),
+                        Ok(None) => println!("Auto-backup: not due"),
+                        Err(e) => println!("Auto-backup error (non-fatal): {}", e),
+                    }
+                });
+            });
 
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -148,6 +167,13 @@ pub fn run() {
             // Settings commands
             commands::settings::restore_from_backup,
             commands::settings::clear_all_data,
+            // Scheduled Backup commands
+            commands::scheduled_backup::get_backup_settings,
+            commands::scheduled_backup::update_backup_settings,
+            commands::scheduled_backup::get_backup_status,
+            commands::scheduled_backup::run_auto_backup_now,
+            commands::scheduled_backup::check_and_run_auto_backup,
+            commands::scheduled_backup::restore_from_zip_backup,
             // Security commands
             commands::security::set_pin,
             commands::security::verify_pin,

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -25,6 +25,11 @@ import {
   Lock,
   Eye,
   EyeOff,
+  FolderOpen,
+  ToggleLeft,
+  ToggleRight,
+  Archive,
+  Image,
 } from "lucide-react";
 import { useTheme } from "../contexts/ThemeContext";
 import { useAccentColor } from "../contexts/AccentColorContext";
@@ -42,6 +47,30 @@ interface AppSettings {
   startOfMonth: number;
   accentColor: string;
   fontSize: string;
+}
+
+// Auto-Backup types
+interface AutoBackupSettings {
+  auto_backup_enabled: boolean;
+  auto_backup_frequency: string;
+  auto_backup_path: string;
+  auto_backup_retention: number;
+  auto_backup_include_photos: boolean;
+  auto_backup_last_run: string;
+}
+
+interface BackupStatus {
+  last_backup_date: string | null;
+  next_due_date: string | null;
+  backup_count: number;
+  is_overdue: boolean;
+}
+
+interface BackupResult {
+  success: boolean;
+  file_path: string;
+  file_size_bytes: number;
+  photos_included: boolean;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -235,8 +264,16 @@ export default function SettingsView() {
   const [showPin, setShowPin] = useState(false);
   const [securityTimeout, setSecurityTimeout] = useState(5);
 
+  // Auto-Backup state
+  const [autoBackupSettings, setAutoBackupSettings] =
+    useState<AutoBackupSettings | null>(null);
+  const [backupStatus, setBackupStatus] = useState<BackupStatus | null>(null);
+  const [isAutoBackingUp, setIsAutoBackingUp] = useState(false);
+  const [isSavingBackupSettings, setIsSavingBackupSettings] = useState(false);
+
   useEffect(() => {
     loadDbStats();
+    loadAutoBackupSettings();
   }, []);
 
   // Load security status on mount
@@ -315,6 +352,127 @@ export default function SettingsView() {
     }
   };
 
+  // —— Auto-Backup handlers ——————————————————————————
+  const loadAutoBackupSettings = async () => {
+    try {
+      const [settings, status] = await Promise.all([
+        invoke<AutoBackupSettings>("get_backup_settings"),
+        invoke<BackupStatus>("get_backup_status"),
+      ]);
+      setAutoBackupSettings(settings);
+      setBackupStatus(status);
+    } catch (err) {
+      console.error("Failed to load auto-backup settings:", err);
+    }
+  };
+
+  const saveAutoBackupSettings = async (updated: AutoBackupSettings) => {
+    setIsSavingBackupSettings(true);
+    try {
+      await invoke("update_backup_settings", { settings: updated });
+      setAutoBackupSettings(updated);
+      // Refresh status after saving
+      const status = await invoke<BackupStatus>("get_backup_status");
+      setBackupStatus(status);
+      success("Settings Saved", "Auto-backup preferences updated.");
+    } catch (err) {
+      showError("Failed to Save", String(err));
+    } finally {
+      setIsSavingBackupSettings(false);
+    }
+  };
+
+  const handleAutoBackupToggle = () => {
+    if (!autoBackupSettings) return;
+    const updated = {
+      ...autoBackupSettings,
+      auto_backup_enabled: !autoBackupSettings.auto_backup_enabled,
+    };
+    saveAutoBackupSettings(updated);
+  };
+
+  const handleBackupFrequencyChange = (freq: string) => {
+    if (!autoBackupSettings) return;
+    const updated = { ...autoBackupSettings, auto_backup_frequency: freq };
+    saveAutoBackupSettings(updated);
+  };
+
+  const handleBackupPathSelect = async () => {
+    if (!autoBackupSettings) return;
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: "Select Backup Folder",
+      });
+      if (selected && typeof selected === "string") {
+        const updated = { ...autoBackupSettings, auto_backup_path: selected };
+        saveAutoBackupSettings(updated);
+      }
+    } catch (err) {
+      showError("Folder Selection Failed", String(err));
+    }
+  };
+
+  const handleRetentionChange = (value: number) => {
+    if (!autoBackupSettings) return;
+    const clamped = Math.max(1, Math.min(50, value));
+    const updated = { ...autoBackupSettings, auto_backup_retention: clamped };
+    saveAutoBackupSettings(updated);
+  };
+
+  const handleIncludePhotosToggle = () => {
+    if (!autoBackupSettings) return;
+    const updated = {
+      ...autoBackupSettings,
+      auto_backup_include_photos: !autoBackupSettings.auto_backup_include_photos,
+    };
+    saveAutoBackupSettings(updated);
+  };
+
+  const handleAutoBackupNow = async () => {
+    setIsAutoBackingUp(true);
+    try {
+      const result = await invoke<BackupResult>("run_auto_backup_now");
+      if (result.success) {
+        success(
+          "Backup Created",
+          `Backup saved to ${result.file_path.split(/[\/\\]/).pop()} (${formatBytes(result.file_size_bytes)})`,
+        );
+        // Refresh status
+        await loadAutoBackupSettings();
+      }
+    } catch (err) {
+      showError("Backup Failed", String(err));
+    } finally {
+      setIsAutoBackingUp(false);
+    }
+  };
+
+  const formatBytes = (bytes: number): string => {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+  };
+
+  const formatAutoBackupDate = (isoStr: string | null | undefined): string => {
+    if (!isoStr) return "Never";
+    try {
+      const date = new Date(isoStr);
+      return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "Unknown";
+    }
+  };
+
   // —— Backup ——————————————————————————————————————————
   const handleBackup = async () => {
     setIsBackingUp(true);
@@ -368,8 +526,13 @@ export default function SettingsView() {
     setIsRestoring(true);
     try {
       const filePath = await open({
-        filters: [{ name: "JSON Files", extensions: ["json"] }],
-        title: "Select Backup File",
+        filters: [
+          {
+            name: "Backup Files",
+            extensions: ["json", "zip"],
+          },
+        ],
+        title: "Select Backup File (.json or .zip)",
         multiple: false,
       });
 
@@ -378,91 +541,135 @@ export default function SettingsView() {
         return;
       }
 
-      const content = await readTextFile(filePath as string);
+      const fileStr = filePath as string;
+      const isZip = fileStr.toLowerCase().endsWith(".zip");
 
-      // Validate JSON structure
-      let backup;
-      try {
-        backup = JSON.parse(content);
-      } catch {
-        showError(
-          "Invalid File",
-          "The selected file is not a valid JSON backup.",
+      if (isZip) {
+        // ── ZIP restore path ──
+        const proceedWithRestore = await ask(
+          `Restore from zip backup?\n\nFile: ${fileStr.split(/[/\\]/).pop()}\n\nThis will replace ALL current data including accounts, categories, transactions, budgets, and photos.\n\nProceed with restore?`,
+          {
+            title: "Confirm Restore",
+            kind: "info",
+            okLabel: "Restore Now",
+            cancelLabel: "Cancel",
+          },
         );
-        setIsRestoring(false);
-        return;
-      }
 
-      if (!backup.version || !backup.data) {
-        showError(
-          "Invalid Backup",
-          "This file does not appear to be a Money Manager backup.",
+        if (!proceedWithRestore) {
+          setIsRestoring(false);
+          return;
+        }
+
+        const result = await invoke<{
+          success: boolean;
+          accounts_restored: number;
+          categories_restored: number;
+          transactions_restored: number;
+          budgets_restored: number;
+          photos_restored: number;
+        }>("restore_from_zip_backup", { zipPath: fileStr });
+
+        if (result.success) {
+          const photoMsg =
+            result.photos_restored > 0
+              ? `, and ${result.photos_restored} photos`
+              : "";
+          success(
+            "Restore Complete",
+            `Restored ${result.accounts_restored} accounts, ${result.categories_restored} categories, ${result.transactions_restored} transactions, ${result.budgets_restored} budgets${photoMsg}.`,
+          );
+        }
+      } else {
+        // ── JSON restore path (existing) ──
+        const content = await readTextFile(fileStr);
+
+        // Validate JSON structure
+        let backup;
+        try {
+          backup = JSON.parse(content);
+        } catch {
+          showError(
+            "Invalid File",
+            "The selected file is not a valid JSON backup.",
+          );
+          setIsRestoring(false);
+          return;
+        }
+
+        if (!backup.version || !backup.data) {
+          showError(
+            "Invalid Backup",
+            "This file does not appear to be a Money Manager backup.",
+          );
+          setIsRestoring(false);
+          return;
+        }
+
+        // Validate expected data keys
+        const requiredKeys = [
+          "accounts",
+          "categories",
+          "transactions",
+          "budgets",
+        ];
+        const missingKeys = requiredKeys.filter(
+          (key) => !(key in backup.data),
         );
-        setIsRestoring(false);
-        return;
-      }
+        if (missingKeys.length > 0) {
+          showError(
+            "Incomplete Backup",
+            `Missing data sections: ${missingKeys.join(", ")}`,
+          );
+          setIsRestoring(false);
+          return;
+        }
 
-      // Validate expected data keys
-      const requiredKeys = [
-        "accounts",
-        "categories",
-        "transactions",
-        "budgets",
-      ];
-      const missingKeys = requiredKeys.filter((key) => !(key in backup.data));
-      if (missingKeys.length > 0) {
-        showError(
-          "Incomplete Backup",
-          `Missing data sections: ${missingKeys.join(", ")}`,
+        // Show what's in the backup
+        const stats = {
+          accounts: Array.isArray(backup.data.accounts)
+            ? backup.data.accounts.length
+            : 0,
+          categories: Array.isArray(backup.data.categories)
+            ? backup.data.categories.length
+            : 0,
+          transactions: Array.isArray(backup.data.transactions)
+            ? backup.data.transactions.length
+            : 0,
+          budgets: Array.isArray(backup.data.budgets)
+            ? backup.data.budgets.length
+            : 0,
+        };
+
+        const proceedWithRestore = await ask(
+          `This backup contains:\n• ${stats.accounts} accounts\n• ${stats.categories} categories\n• ${stats.transactions} transactions\n• ${stats.budgets} budgets\n\nBackup date: ${backup.exported_at ? new Date(backup.exported_at).toLocaleString() : "Unknown"}\n\nProceed with restore?`,
+          {
+            title: "Confirm Restore",
+            kind: "info",
+            okLabel: "Restore Now",
+            cancelLabel: "Cancel",
+          },
         );
-        setIsRestoring(false);
-        return;
-      }
 
-      // Show what's in the backup
-      const stats = {
-        accounts: Array.isArray(backup.data.accounts)
-          ? backup.data.accounts.length
-          : 0,
-        categories: Array.isArray(backup.data.categories)
-          ? backup.data.categories.length
-          : 0,
-        transactions: Array.isArray(backup.data.transactions)
-          ? backup.data.transactions.length
-          : 0,
-        budgets: Array.isArray(backup.data.budgets)
-          ? backup.data.budgets.length
-          : 0,
-      };
+        if (!proceedWithRestore) {
+          setIsRestoring(false);
+          return;
+        }
 
-      const proceedWithRestore = await ask(
-        `This backup contains:\n• ${stats.accounts} accounts\n• ${stats.categories} categories\n• ${stats.transactions} transactions\n• ${stats.budgets} budgets\n\nBackup date: ${backup.exported_at ? new Date(backup.exported_at).toLocaleString() : "Unknown"}\n\nProceed with restore?`,
-        {
-          title: "Confirm Restore",
-          kind: "info",
-          okLabel: "Restore Now",
-          cancelLabel: "Cancel",
-        },
-      );
+        const result = await invoke<{
+          success: boolean;
+          accounts_restored: number;
+          categories_restored: number;
+          transactions_restored: number;
+          budgets_restored: number;
+        }>("restore_from_backup", { backupJson: content });
 
-      if (!proceedWithRestore) {
-        setIsRestoring(false);
-        return;
-      }
-
-      const result = await invoke<{
-        success: boolean;
-        accounts_restored: number;
-        categories_restored: number;
-        transactions_restored: number;
-        budgets_restored: number;
-      }>("restore_from_backup", { backupJson: content });
-
-      if (result.success) {
-        success(
-          "Restore Complete",
-          `Restored ${result.accounts_restored} accounts, ${result.categories_restored} categories, ${result.transactions_restored} transactions, and ${result.budgets_restored} budgets.`,
-        );
+        if (result.success) {
+          success(
+            "Restore Complete",
+            `Restored ${result.accounts_restored} accounts, ${result.categories_restored} categories, ${result.transactions_restored} transactions, and ${result.budgets_restored} budgets.`,
+          );
+        }
       }
 
       await loadDbStats();
@@ -885,7 +1092,7 @@ export default function SettingsView() {
                 Restore Backup
               </p>
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                Import data from file
+                Import from JSON or ZIP file
               </p>
             </div>
           </button>
@@ -908,6 +1115,220 @@ export default function SettingsView() {
             </div>
           </button>
         </div>
+      </SettingSection>
+
+      {/* ═══ Auto-Backup ═══ */}
+      <SettingSection
+        icon={
+          <Archive className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+        }
+        title="Auto-Backup"
+        description="Configure automatic database backups on app startup"
+      >
+        {autoBackupSettings && (
+          <>
+            {/* Enable/Disable Toggle */}
+            <div className="flex items-center justify-between p-4 rounded-lg bg-gray-50 dark:bg-gray-700/30 border border-gray-100 dark:border-gray-700">
+              <div className="flex items-center gap-3">
+                <div
+                  className={`p-2 rounded-lg ${
+                    autoBackupSettings.auto_backup_enabled
+                      ? "bg-emerald-100 dark:bg-emerald-900/30"
+                      : "bg-gray-100 dark:bg-gray-700"
+                  }`}
+                >
+                  <Archive
+                    className={`w-5 h-5 ${
+                      autoBackupSettings.auto_backup_enabled
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : "text-gray-400"
+                    }`}
+                  />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    Automatic Backup
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {autoBackupSettings.auto_backup_enabled
+                      ? "Enabled — Backups run automatically on app startup"
+                      : "Disabled — Click to enable automatic backups"}
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={handleAutoBackupToggle}
+                disabled={isSavingBackupSettings}
+                className="focus:outline-none disabled:opacity-50"
+              >
+                {autoBackupSettings.auto_backup_enabled ? (
+                  <ToggleRight className="w-10 h-10 text-emerald-500" />
+                ) : (
+                  <ToggleLeft className="w-10 h-10 text-gray-400" />
+                )}
+              </button>
+            </div>
+
+            {/* Status Display */}
+            {autoBackupSettings.auto_backup_enabled && backupStatus && (
+              <div
+                className={`p-4 rounded-lg border ${
+                  backupStatus.is_overdue
+                    ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+                    : "border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/30"
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Clock className="w-4 h-4 text-gray-400" />
+                      <span className="text-sm text-gray-900 dark:text-white">
+                        Last backup:{" "}
+                        <span className="font-medium">
+                          {formatAutoBackupDate(
+                            backupStatus.last_backup_date,
+                          )}
+                        </span>
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Calendar className="w-4 h-4 text-gray-400" />
+                      <span className="text-sm text-gray-900 dark:text-white">
+                        Next due:{" "}
+                        <span className="font-medium">
+                          {formatAutoBackupDate(backupStatus.next_due_date)}
+                        </span>
+                      </span>
+                    </div>
+                    {backupStatus.backup_count > 0 && (
+                      <div className="flex items-center gap-2">
+                        <Archive className="w-4 h-4 text-gray-400" />
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          {backupStatus.backup_count} backup
+                          {backupStatus.backup_count !== 1 ? "s" : ""} stored
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {backupStatus.is_overdue && (
+                      <span className="px-2 py-1 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+                        Overdue
+                      </span>
+                    )}
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={handleAutoBackupNow}
+                      disabled={
+                        isAutoBackingUp ||
+                        !autoBackupSettings.auto_backup_path
+                      }
+                      icon={
+                        isAutoBackingUp ? (
+                          <RefreshCw className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Download className="w-4 h-4" />
+                        )
+                      }
+                    >
+                      {isAutoBackingUp ? "Backing up..." : "Backup Now"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Settings (shown when enabled) */}
+            {autoBackupSettings.auto_backup_enabled && (
+              <>
+                <SettingRow
+                  label="Backup Frequency"
+                  description="How often auto-backup runs on app startup"
+                >
+                  <Select
+                    value={autoBackupSettings.auto_backup_frequency}
+                    onChange={(e) =>
+                      handleBackupFrequencyChange(e.target.value)
+                    }
+                    options={[
+                      { value: "DAILY", label: "Daily" },
+                      { value: "WEEKLY", label: "Weekly" },
+                      { value: "MONTHLY", label: "Monthly" },
+                    ]}
+                  />
+                </SettingRow>
+
+                <SettingRow
+                  label="Backup Folder"
+                  description={
+                    autoBackupSettings.auto_backup_path
+                      ? autoBackupSettings.auto_backup_path
+                      : "No folder selected"
+                  }
+                >
+                  <button
+                    onClick={handleBackupPathSelect}
+                    className="w-full flex items-center justify-between px-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <FolderOpen className="w-4 h-4 text-gray-400" />
+                      <span className="text-sm text-gray-900 dark:text-white truncate">
+                        {autoBackupSettings.auto_backup_path
+                          ? autoBackupSettings.auto_backup_path
+                              .split(/[\/\\]/)
+                              .pop()
+                          : "Choose folder..."}
+                      </span>
+                    </div>
+                    <ChevronRight className="w-4 h-4 text-gray-400" />
+                  </button>
+                </SettingRow>
+
+                <SettingRow
+                  label="Keep Last N Backups"
+                  description="Older backups are automatically deleted"
+                >
+                  <input
+                    type="number"
+                    min={1}
+                    max={50}
+                    value={autoBackupSettings.auto_backup_retention}
+                    onChange={(e) =>
+                      handleRetentionChange(Number(e.target.value))
+                    }
+                    className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </SettingRow>
+
+                <div className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-700/30 border border-gray-100 dark:border-gray-700">
+                  <div className="flex items-center gap-3">
+                    <Image className="w-4 h-4 text-gray-400" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                        Include Photos
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Receipt photos will be included in the backup zip
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={handleIncludePhotosToggle}
+                    disabled={isSavingBackupSettings}
+                    className="focus:outline-none disabled:opacity-50"
+                  >
+                    {autoBackupSettings.auto_backup_include_photos ? (
+                      <ToggleRight className="w-8 h-8 text-emerald-500" />
+                    ) : (
+                      <ToggleLeft className="w-8 h-8 text-gray-400" />
+                    )}
+                  </button>
+                </div>
+              </>
+            )}
+          </>
+        )}
       </SettingSection>
 
       {/* ═══ Security ═══ */}


### PR DESCRIPTION
… support

Closes #27

- Backend: new [scheduled_backup.rs] with 6 Tauri commands: get/update backup settings, get status, run now, startup check, restore from zip
- Migration: seed auto-backup settings in `app_settings` table
- Backup creates `.zip` with `backup.json` + optional photos directory
- Retention management auto-deletes oldest backups when limit exceeded
- Silent startup check runs in background thread, never blocks UI
- Refactor [restore_from_backup] to support internal reuse
- Backup JSON now includes [transaction_photos] for full photo restore
- Zip restore extracts photos, remaps transaction IDs, re-links receipts
- Frontend: new Auto-Backup section in Settings with toggle, frequency, folder picker, retention input, include-photos toggle, status display
- Restore dialog now accepts both [.json] crate dependency